### PR TITLE
Update the underlying image to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic as openssl-build
-MAINTAINER Hans Rakers <h.rakers@global.leaseweb.com>
+LABEL maintainer="Hans Rakers <h.rakers@global.leaseweb.com>"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
@@ -80,34 +80,40 @@ FROM ubuntu:bionic as php-build
 COPY --from=openssl-build "/usr/local/ssl/" "/usr/local/ssl/"
 COPY --from=curl-build "/usr/local/curl/" "/usr/local/curl/"
 
-# persistent / runtime deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates \
-      curl \
-      librecode0 \
-      libsqlite3-0 \
-      libxml2 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# phpize deps
+# build dependencies for php-5.3
+# php 5.3 needs older autoconf
 RUN apt-get update && apt-get install -y --no-install-recommends \
       autoconf \
+      autoconf2.13 \
+      ca-certificates \
+      curl \
       file \
       g++ \
       gcc \
       gnupg \
+      libbz2-dev \
       libc-dev \
+      libedit-dev \
+      libidn2-dev \
+      libmcrypt-dev \
+      libnghttp2-dev \
+      libpsl-dev \
+      libreadline6-dev \
+      librecode-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libxml2-dev \
       make \
       pkg-config \
       re2c \
+      xz-utils \
+      zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PHP_INI_DIR /usr/local/etc/php
-RUN mkdir -p $PHP_INI_DIR/conf.d
 
-ENV GPG_KEYS 0B96609E270F565C13292B24C13C70B87267B52D 0A95E9A026542D53835E3F3A7DEC4E69FC9C83D7
+ENV GPG_KEYS 0B96609E270F565C13292B24C13C70B87267B52D 0A95E9A026542D53835E3F3A7DEC4E69FC9C83D7 A4A9406876FCBD3C456770C88C718D3B5072E1F5
 RUN set -xe \
   && mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
   && for key in $GPG_KEYS; do \
@@ -116,31 +122,43 @@ RUN set -xe \
 
 ENV PHP_VERSION 5.3.29
 
-# php 5.3 needs older autoconf
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-group=www-data --disable-cgi
+
+# Apply stack smash protection to functions using local buffers and alloca()
+# Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)
+# Enable optimization (-O2)
+# Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
+# https://github.com/docker-library/php/issues/272
+# -D_LARGEFILE_SOURCE and -D_FILE_OFFSET_BITS=64 (https://www.php.net/manual/en/intro.filesystem.php)
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -pie"
+
+COPY docker-php-source /usr/local/bin/
+
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
-RUN buildDeps=" \
-                autoconf2.13 \
-                libbz2-dev \
-                libidn2-dev \
-                libmcrypt-dev \
-                libnghttp2-dev \
-                libpsl-dev \
-                libreadline6-dev \
-                librecode-dev \
-                libsqlite3-dev \
-                libssl-dev \
-                libxml2-dev \
-                xz-utils \
-      " \
-      && set -x \
-      && apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+RUN set -eux \
+      # Install MySQL 5.7 client library and headers (the system package is compiled against OpenSSL 1.1, which we can't use)
+      && cd /usr/src \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb" -o libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb.asc" -o libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb" -o libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb.asc" -o libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/mysql-common_5.7.30-1ubuntu18.04_amd64.deb" -o mysql-common_5.7.30-1ubuntu18.04_amd64.deb \
+      && curl -SL "http://mirror.nl.leaseweb.net/mysql/Downloads/MySQL-5.7/mysql-common_5.7.30-1ubuntu18.04_amd64.deb.asc" -o mysql-common_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && gpg --verify libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && gpg --verify libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && gpg --verify mysql-common_5.7.30-1ubuntu18.04_amd64.deb.asc \
+      && dpkg -i libmysqlclient-dev_5.7.30-1ubuntu18.04_amd64.deb libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb mysql-common_5.7.30-1ubuntu18.04_amd64.deb \
       && curl -SL "http://nl.php.net/get/php-$PHP_VERSION.tar.xz/from/this/mirror" -o php.tar.xz \
       && curl -SL "http://nl.php.net/get/php-$PHP_VERSION.tar.xz.asc/from/this/mirror" -o php.tar.xz.asc \
       && gpg --verify php.tar.xz.asc \
-      && mkdir -p /usr/src/php \
-      && tar -xof php.tar.xz -C /usr/src/php --strip-components=1 \
-      && rm php.tar.xz* \
+      && docker-php-source extract \
       && cd /usr/src/php \
+      && export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
       && ./configure \
             --with-config-file-path="$PHP_INI_DIR" \
             --with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
@@ -157,41 +175,89 @@ RUN buildDeps=" \
             --with-gettext \
             --with-mcrypt \
             --with-mhash \
+            --with-mysql \
+            --with-pdo-mysql \
+            --with-pdo-sqlite=/usr \
+		        --with-sqlite3=/usr \
+            --with-libedit \
+            --with-zlib \
             --enable-bcmath \
             --enable-ftp \
             --enable-intl \
             --enable-mbstring \
+            --enable-mysqlnd \
             --enable-soap \
             --enable-zip \
+            ${PHP_EXTRA_CONFIGURE_ARGS:-} \
       && sed -i '/EXTRA_LIBS = /s|$| -lstdc++|' Makefile \
-      && make -j$(nproc)
+      && make -j$(nproc) \
+      && find -type f -name '*.a' -delete
 
 FROM ubuntu:bionic
 
-# persistent / runtime deps
+COPY --from=php-build "/usr/src/" "/usr/src/"
+
+COPY docker-php-* /usr/local/bin/
+
+# prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
+# persistent / runtime deps and deps required for compiling extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \
+      autoconf \
       binutils \
       ca-certificates \
-      libcurl3 \
+      curl \
+      file \
+      g++ \
+      gcc \
+      gnupg \
+      libc-dev \
+      libedit2 \
+      libidn2-0 \
+      libnghttp2-14 \
       librecode0 \
       libmcrypt4 \
+      libpsl5 \
       libreadline7 \
       libsqlite3-0 \
       libxml2 \
       make \
+      pkg-config \
+      re2c \
+      xz-utils \
+    # Install MySQL 5.7 client library and headers (the system package is compiled against OpenSSL 1.1)
+    && cd /usr/src \
+    && dpkg -i libmysqlclient20_5.7.30-1ubuntu18.04_amd64.deb mysql-common_5.7.30-1ubuntu18.04_amd64.deb \
+    && rm /usr/src/*amd64.deb* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=php-build "/usr/src/php/" "/usr/src/php/"
-COPY --from=php-build "/usr/local/etc/php/" "/usr/local/etc/php/"
+ENV PHP_INI_DIR /usr/local/etc/php
 
-RUN cd /usr/src/php \
-    && make install \
-    && { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-    && make clean
-
-# COPY --from=php-build "/usr/local/php/" "/usr/local/"
-COPY docker-php-* /usr/local/bin/
+RUN set -eux; \
+    mkdir -p "$PHP_INI_DIR/conf.d"; \
+# allow running as an arbitrary user (https://github.com/docker-library/php/issues/743)
+    [ ! -d /var/www/html ]; \
+    mkdir -p /var/www/html; \
+    chown www-data:www-data /var/www/html; \
+    chmod 777 /var/www/html; \
+    cd /usr/src/php; \
+    make install; \
+    { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; }; \
+    make clean; \
+    cp -v php.ini-* "$PHP_INI_DIR/"; \
+    cd /; \
+	  docker-php-source delete; \
+    pecl update-channels; \
+    rm -rf /tmp/pear ~/.pearrc; \
+    php --version
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
@@ -221,6 +287,8 @@ RUN set -ex \
     echo '; if we send this to /proc/self/fd/1, it never appears'; \
     echo 'access.log = /proc/self/fd/2'; \
     echo; \
+    echo 'clear_env = no'; \
+		echo; \
     echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
     echo 'catch_workers_output = yes'; \
   } | tee php-fpm.d/docker.conf \
@@ -230,13 +298,14 @@ RUN set -ex \
     echo; \
     echo '[www]'; \
     echo 'listen = 9000'; \
-  } | tee php-fpm.d/zz-docker.conf \
-  && pecl update-channels \
-  && rm -rf /tmp/pear ~/.pearrc \
-  && php --version
+  } | tee php-fpm.d/zz-docker.conf
 
 # fix some weird corruption in this file
 RUN sed -i -e "" /usr/local/etc/php-fpm.d/www.conf
+
+# Override stop signal to stop process gracefully
+# https://github.com/php/php-src/blob/17baa87faddc2550def3ae7314236826bc1b1398/sapi/fpm/php-fpm.8.in#L163
+STOPSIGNAL SIGQUIT
 
 EXPOSE 9000
 CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # docker-php-5.3
-PHP-5.3.29 in a Ubuntu 16.04 container for legacy applications. Loosely based on the last official php Dockerfile for PHP-5.3,
-it uses a multi-stage build for compilation of OpenSSL 1.0 and PHP.
+PHP-5.3.29 in a Ubuntu 18.04 container for legacy applications. Loosely based on the last official php Dockerfile for PHP-5.3,
+it uses a multi-stage build for compilation of OpenSSL 1.0, curl and PHP.
+
+## But... Why?
+
+Because we have some legacy Symfony apps running that will eventually be phased out, and are not worth rewriting. These apps can now be isolated, allowing us to keep the underlying OS up-to-date.
+
+## Current versions used
+* Ubuntu 18.04
+* PHP 5.3.29
+* OpenSSL 1.0.2u
+* Curl 7.71.1
+* MySQL 5.7.30
+
+See the [README](https://github.com/docker-library/docs/blob/master/php/README.md) of the official PHP Docker image for information on how to use this image.

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -1,19 +1,69 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
+usage() {
+	echo "usage: $0 ext-name [configure flags]"
+	echo "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
+	echo
+	echo 'Possible values for ext-name:'
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
+}
+
 ext="$1"
-extDir="/usr/src/php/ext/$ext"
-if [ -z "$ext" -o ! -d "$extDir" ]; then
-    echo >&2 "usage: $0 ext-name [configure flags]"
-    echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
-    echo >&2
-    echo >&2 'Possible values for ext-name:'
-    echo >&2 $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
-    exit 1
+if [ -z "$ext" ] || [ ! -d "$ext" ]; then
+	usage >&2
+	exit 1
 fi
 shift
 
-set -x
-cd "$extDir"
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+	fi
+fi
+
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
+cd "$ext"
 phpize
 ./configure "$@"

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -e
+
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
+cd "$extDir"
+
+usage() {
+	echo "usage: $0 [options] module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --ini-name 0-apc.ini apcu apc"
+	echo
+	echo 'Possible values for module-name:'
+	find -maxdepth 1 \
+			-type f \
+			-name '*.so' \
+			-exec basename '{}' ';' \
+		| sort \
+		| xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
+}
+
+opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+iniName=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--help|-h|'-?') usage && exit 0 ;;
+		--ini-name) iniName="$1" && shift ;;
+		--) break ;;
+		*)
+			{
+				echo "error: unknown flag: $flag"
+				usage
+			} >&2
+			exit 1
+			;;
+	esac
+done
+
+modules=
+for module; do
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		# allow ".so" to be optional
+		module="$module.so"
+	fi
+	if ! [ -f "$module" ]; then
+		echo >&2 "error: '$module' does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules="$modules $module"
+done
+
+if [ -z "$modules" ]; then
+	usage >&2
+	exit 1
+fi
+
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
+for module in $modules; do
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		absModule="$(readlink -f "$module")"
+		line="zend_extension=$absModule"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	case "$iniName" in
+		/*)
+			# allow an absolute path
+			ini="$iniName"
+			;;
+		*)
+			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
+			;;
+	esac
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del --no-network $apkDel
+fi

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -1,60 +1,124 @@
-#!/bin/bash
+#!/bin/sh
 set -e
+
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
 
 cd /usr/src/php/ext
 
 usage() {
-    echo "usage: $0 ext-name [ext-name ...]"
-    echo "   ie: $0 gd mysqli"
-    echo "       $0 pdo pdo_mysql"
-    echo
-    echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
-    echo
-    echo 'Possible values for ext-name:'
-    echo $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
+	echo "usage: $0 [-jN] [--ini-name file.ini] ext-name [ext-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo "       $0 -j5 gd mbstring mysqli pdo pdo_mysql shmop"
+	echo
+	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
+	echo
+	echo 'Possible values for ext-name:'
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-exts=()
-while [ $# -gt 0 ]; do
-    ext="$1"
-    shift
-    if [ -z "$ext" ]; then
-        continue
-    fi
-    if [ ! -d "$ext" ]; then
-        echo >&2 "error: $(pwd -P)/$ext does not exist"
-        echo >&2
-        usage >&2
-        exit 1
-    fi
-    exts+=( "$ext" )
+opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+j=1
+iniName=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--help|-h|'-?') usage && exit 0 ;;
+		--ini-name) iniName="$1" && shift ;;
+		--jobs|-j) j="$1" && shift ;;
+		--) break ;;
+		*)
+			{
+				echo "error: unknown flag: $flag"
+				usage
+			} >&2
+			exit 1
+			;;
+	esac
 done
 
-if [ "${#exts[@]}" -eq 0 ]; then
-    usage >&2
-    exit 1
+exts=
+for ext; do
+	if [ -z "$ext" ]; then
+		continue
+	fi
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	exts="$exts $ext"
+done
+
+if [ -z "$exts" ]; then
+	usage >&2
+	exit 1
 fi
 
-for ext in "${exts[@]}"; do
-    (
-        cd "$ext"
-        [ -e Makefile ] || docker-php-ext-configure "$ext"
-        make
-        make install
-        ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-        for module in modules/*.so; do
-            if [ -f "$module" ]; then
-                if grep -q zend_extension_entry "$module"; then
-                    # https://wiki.php.net/internals/extensions#loading_zend_extensions
-                    line="zend_extension=$(readlink -f "$module")"
-                else
-                    line="extension=$(basename "$module")"
-                fi
-                if ! grep -q "$line" "$ini" 2>/dev/null; then
-                    echo "$line" >> "$ini"
-                fi
-            fi
-        done
-        make clean
-    )
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if [ -n "$PHPIZE_DEPS" ]; then
+		if apk info --installed .phpize-deps-configure > /dev/null; then
+			apkDel='.phpize-deps-configure'
+		elif ! apk info --installed .phpize-deps > /dev/null; then
+			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apkDel='.phpize-deps'
+		fi
+	fi
+fi
+
+popDir="$PWD"
+for ext in $exts; do
+	cd "$ext"
+	[ -e Makefile ] || docker-php-ext-configure "$ext"
+	make -j"$j"
+	make -j"$j" install
+	find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-exec basename '{}' ';' \
+			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	make -j"$j" clean
+	cd "$popDir"
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del --no-network $apkDel
+fi
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/docker-php-source
+++ b/docker-php-source
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+dir=/usr/src/php
+
+usage() {
+	echo "usage: $0 COMMAND"
+	echo
+	echo "Manage php source tarball lifecycle."
+	echo
+	echo "Commands:"
+	echo "   extract  extract php source tarball into directory $dir if not already done."
+	echo "   delete   delete extracted php source located into $dir if not already done."
+	echo
+}
+
+case "$1" in
+	extract)
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
+			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
+			touch "$dir/.docker-extracted"
+		fi
+		;;
+
+	delete)
+		rm -rf "$dir"
+		;;
+
+	*)
+		usage
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Update base image to Ubuntu 18.04. Compile OpenSSL and cUrl ourselves and use Mysql's libmysqlclient packages because Ubuntu 18.04 uses OpenSSL 1.1, which PHP 5.3 does not support.
